### PR TITLE
add check calls with deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okareo-ts-sdk",
-  "version": "0.0.30",
+  "version": "0.0.29",
   "main": "dist/index.min.js",
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okareo-ts-sdk",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "main": "dist/index.min.js",
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",

--- a/src/okareo.ts
+++ b/src/okareo.ts
@@ -466,5 +466,28 @@ export class Okareo {
         return this.get_check(evaluator_id);
     }
 
+    async delete_check(evaluator_id: string, evaluator_name: string): Promise<string> {
+        const client = createClient<paths>({ baseUrl: this.endpoint });
+        const { error } = await client.DELETE(`/v0/evaluator/{evaluator_id}`, {
+            params: {
+                header: {
+                    "api-key": this.api_key
+                },
+                path: { evaluator_id: evaluator_id }
+            },
+            body: { name: evaluator_name }
+        });
+        if (error) {
+            throw error;
+        }
+        return "Check deletion was successful";
+    }
+
+
+    async delete_evaluator(evaluator_id: string, evaluator_name: string): Promise<string> {
+        console.warn(CHECK_DEPRECATION_WARNING);
+        return this.delete_check(evaluator_id, evaluator_name);
+    }
+
 
 }

--- a/src/okareo.ts
+++ b/src/okareo.ts
@@ -4,6 +4,9 @@ import type { paths, components } from "./api/v1/okareo_endpoints";
 import FormData from "form-data";
 import * as fs from "fs";
 
+const CHECK_DEPRECATION_WARNING = "The `evaluator` naming convention is deprecated and will not be supported in a future release. " +
+"Please use `check` in place of `evaluator` when invoking this method.";
+
 export interface OkareoProps {
     api_key: string;
     endpoint?: string;
@@ -311,7 +314,7 @@ export class Okareo {
     }
 
     
-    async generate_evaluator(props: components["schemas"]["EvaluatorSpecRequest"]): Promise<components["schemas"]["EvaluatorGenerateResponse"]> {
+    async generate_check(props: components["schemas"]["EvaluatorSpecRequest"]): Promise<components["schemas"]["EvaluatorGenerateResponse"]> {
         if (!this.api_key || this.api_key.length === 0) { throw new Error("API Key is required"); }
         const client = createClient<paths>({ baseUrl: this.endpoint });
         const { data, error } = await client.POST("/v0/evaluator_generate", {
@@ -330,7 +333,13 @@ export class Okareo {
     }
 
 
-    async upload_evaluator(props: UploadEvaluatorProps): Promise<components["schemas"]["EvaluatorDetailedResponse"]> {
+    async generate_evaluator(props: components["schemas"]["EvaluatorSpecRequest"]): Promise<components["schemas"]["EvaluatorGenerateResponse"]> {
+        console.warn(CHECK_DEPRECATION_WARNING);
+        return this.generate_check(props);
+    }
+
+
+    async upload_check(props: UploadEvaluatorProps): Promise<components["schemas"]["EvaluatorDetailedResponse"]> {
         if (!this.api_key || this.api_key.length === 0) { throw new Error("API Key is required"); }
         const eLength = this.endpoint.length;
         const api_endpoint = ((this.endpoint.substring(eLength-1) === "/")?this.endpoint.substring(0, eLength-1):this.endpoint)+"/v0/evaluator_upload";
@@ -404,7 +413,14 @@ export class Okareo {
             });
     }
 
-    async get_all_evaluators(): Promise<components["schemas"]["EvaluatorBriefResponse"][]> {
+
+    async upload_evaluator(props: UploadEvaluatorProps): Promise<components["schemas"]["EvaluatorDetailedResponse"]> {
+        console.warn(CHECK_DEPRECATION_WARNING);
+        return this.upload_check(props);
+    }
+
+
+    async get_all_checks(): Promise<components["schemas"]["EvaluatorBriefResponse"][]> {
         if (!this.api_key || this.api_key.length === 0) { throw new Error("API Key is required"); }
         const client = createClient<paths>({ baseUrl: this.endpoint });
         const { data, error } = await client.GET("/v0/evaluators", {
@@ -420,7 +436,14 @@ export class Okareo {
         return data || {};
     }
 
-    async get_evaluator(evaluator_id: string): Promise<components["schemas"]["EvaluatorDetailedResponse"]> {
+
+    async get_all_evaluators(): Promise<components["schemas"]["EvaluatorBriefResponse"][]> {
+        console.warn(CHECK_DEPRECATION_WARNING);
+        return this.get_all_checks();
+    }
+
+
+    async get_check(evaluator_id: string): Promise<components["schemas"]["EvaluatorDetailedResponse"]> {
         if (!this.api_key || this.api_key.length === 0) { throw new Error("API Key is required"); }
         const client = createClient<paths>({ baseUrl: this.endpoint });
         const { data, error } = await client.GET("/v0/evaluator/{evaluator_id}", {
@@ -435,6 +458,12 @@ export class Okareo {
             throw error;
         }
         return data || {};
+    }
+
+
+    async get_evaluator(evaluator_id: string): Promise<components["schemas"]["EvaluatorDetailedResponse"]> {
+        console.warn(CHECK_DEPRECATION_WARNING);
+        return this.get_check(evaluator_id);
     }
 
 

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -47,12 +47,12 @@ describe('Checks', () => {
             output_data_type: "boolean",
         }
 
-        const check: any = await okareo.generate_evaluator(check_info);
-        let upload_check = await okareo.upload_evaluator({
+        const check: any = await okareo.generate_check(check_info);
+        let upload_check = await okareo.upload_check({
             ...check_info,
             generated_code: check.generated_code,
         });
-        upload_check = await okareo.upload_evaluator({
+        upload_check = await okareo.upload_check({
             ...check_info,
             generated_code: check.generated_code,
             update: true,

--- a/tests/evaluator.test.ts
+++ b/tests/evaluator.test.ts
@@ -16,15 +16,15 @@ describe('Evaluators', () => {
       requires_scenario_result: false,
       output_data_type: "boolean",
     }
-    const genData: any = await okareo.generate_evaluator(genConfig);
+    const genData: any = await okareo.generate_check(genConfig);
     const { generated_code } = genData;
     
-    const data: any = await okareo.upload_evaluator(
+    const data: any = await okareo.upload_check(
       {
         project_id: genConfig.project_id,
         name: "Question Detector NEW",
         description: genConfig.description,
-        evaluator_code: generated_code,
+        generated_code: generated_code,
         requires_scenario_input: genConfig.requires_scenario_input,
         requires_scenario_result: genConfig.requires_scenario_result,
         output_data_type: "boolean"
@@ -33,6 +33,8 @@ describe('Evaluators', () => {
     console.log("data",JSON.stringify(data));
     expect(data).toBeDefined();
 
+    const delData = await okareo.delete_check(data.id, data.name);
+    expect(delData).toEqual("Check deletion was successful");
   });
 
   it('Upload Evaluator', async () =>  {
@@ -48,7 +50,7 @@ describe('Evaluators', () => {
       requires_scenario_result: false,
       output_data_type: "boolean",
     }
-    const data: any = await okareo.upload_evaluator(
+    const data: any = await okareo.upload_check(
       {
         project_id: genConfig.project_id,
         name: "Question Detector ALT",
@@ -60,13 +62,16 @@ describe('Evaluators', () => {
       }
     );
     expect(data).toBeDefined();
+
+    const delData = await okareo.delete_check(data.id, data.name);
+    expect(delData).toEqual("Check deletion was successful");
   });
 
   it('Get All Evaluators', async () =>  {
     const okareo = new Okareo({api_key:OKAREO_API_KEY, endpoint: OKAREO_BASE_URL });
     const pData: any[] = await okareo.getProjects();
     const project_id = pData.find(p => p.name === "Global")?.id;
-    const allEvals = await okareo.get_all_evaluators();
+    const allEvals = await okareo.get_all_checks();
     expect(allEvals).toBeDefined();
   });
 
@@ -74,11 +79,11 @@ describe('Evaluators', () => {
     const okareo = new Okareo({api_key:OKAREO_API_KEY, endpoint: OKAREO_BASE_URL });
     const pData: any[] = await okareo.getProjects();
     const project_id = pData.find(p => p.name === "Global")?.id;
-    const allEvals = await okareo.get_all_evaluators();
+    const allEvals = await okareo.get_all_checks();
     let evalObj;
     if (allEvals.length > 0) {
       const eval_id = allEvals[0].id;
-      evalObj = (eval_id)?await okareo.get_evaluator(eval_id):null;
+      evalObj = (eval_id)?await okareo.get_check(eval_id):null;
     }
     expect(evalObj).toBeDefined();
   });


### PR DESCRIPTION
- Adds `delete_check` SDK method + test for this method
- Renames `evaluator` methods with equivalent `check` methods.
- Displays a deprecation warning when invoking the `evaluator` named method. 
- Updates tests to use `check` methods
- Updates version to 0.0.30